### PR TITLE
 Solved unused attribute issue similar to mu

### DIFF
--- a/001trace.cc
+++ b/001trace.cc
@@ -75,7 +75,7 @@ trace_stream* Trace_stream = NULL;
 
 // RAISE << die exits after printing -- unless Hide_warnings is set.
 struct die {};
-ostream& operator<<(ostream& os, unused die) {
+ostream& operator<<(ostream& os, vestigial die) {
   if (Hide_warnings) return os;
   os << "dying";
   exit(1);

--- a/006infix.cc
+++ b/006infix.cc
@@ -233,6 +233,6 @@ bool is_parseable_as_float(string s) {
 
 const char* skip_float(const char* s) {
   char* end = NULL;
-  unused float dummy = strtof(s, &end);
+  vestigial float dummy = strtof(s, &end);
   return end;
 }

--- a/027stream.cc
+++ b/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/alternatives/lite/006infix.cc
+++ b/alternatives/lite/006infix.cc
@@ -233,6 +233,6 @@ bool is_parseable_as_float(string s) {
 
 const char* skip_float(const char* s) {
   char* end = NULL;
-  unused float dummy = strtof(s, &end);
+  vestigial float dummy = strtof(s, &end);
   return end;
 }

--- a/alternatives/lite/027stream.cc
+++ b/alternatives/lite/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/alternatives/lite/orig/006infix.cc
+++ b/alternatives/lite/orig/006infix.cc
@@ -233,6 +233,6 @@ bool is_parseable_as_float(string s) {
 
 const char* skip_float(const char* s) {
   char* end = NULL;
-  unused float dummy = strtof(s, &end);
+  vestigial float dummy = strtof(s, &end);
   return end;
 }

--- a/alternatives/lite/orig/027stream.cc
+++ b/alternatives/lite/orig/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/boot.cc
+++ b/boot.cc
@@ -2,7 +2,7 @@
 //  no pointers except cell*
 //  use long as the default integer type; it's always large enough to hold pointers
 
-#define unused __attribute__((unused))
+#define vestigial __attribute__((unused))
 
 #include<cstdio>
 #include<cstring>

--- a/literate/002trace
+++ b/literate/002trace
@@ -173,7 +173,7 @@ trace_stream* Trace_stream = NULL;
 // RAISE << die exits after printing -- unless Hide_warnings is set.
 struct die {};
 :(before "End Tracing")
-ostream& operator<<(ostream& os, unused die) {
+ostream& operator<<(ostream& os, vestigial die) {
   if (Hide_warnings) return os;
   os << "dying";
   if (Trace_stream) Trace_stream->newline();
@@ -475,4 +475,4 @@ using std::ostringstream;
 using std::ifstream;
 using std::ofstream;
 
-#define unused  __attribute__((unused))
+#define vestigial  __attribute__((unused))

--- a/literate/009includes
+++ b/literate/009includes
@@ -44,4 +44,4 @@ using std::ostringstream;
 using std::ifstream;
 using std::ofstream;
 
-#define unused  __attribute__((unused))
+#define vestigial  __attribute__((unused))

--- a/literate/alt1.0/002trace
+++ b/literate/alt1.0/002trace
@@ -97,7 +97,7 @@ trace_stream* Trace_stream = NULL;
 // RAISE << die exits after printing -- unless Hide_warnings is set.
 struct die {};
 :(before "End Tracing")
-ostream& operator<<(ostream& os, unused die) {
+ostream& operator<<(ostream& os, vestigial die) {
   if (Hide_warnings) return os;
   os << "dying";
   if (Trace_stream) Trace_stream->newline();

--- a/literate/alt1.0/009includes
+++ b/literate/alt1.0/009includes
@@ -44,4 +44,4 @@ using std::ostringstream;
 using std::ifstream;
 using std::ofstream;
 
-#define unused  __attribute__((unused))
+#define vestigial  __attribute__((unused))

--- a/literate/alt1/002trace
+++ b/literate/alt1/002trace
@@ -97,7 +97,7 @@ trace_stream* Trace_stream = NULL;
 // RAISE << die exits after printing -- unless Hide_warnings is set.
 struct die {};
 :(before "End Tracing")
-ostream& operator<<(ostream& os, unused die) {
+ostream& operator<<(ostream& os, vestigial die) {
   if (Hide_warnings) return os;
   os << "dying";
   if (Trace_stream) Trace_stream->newline();

--- a/literate/alt1/009includes
+++ b/literate/alt1/009includes
@@ -44,4 +44,4 @@ using std::ostringstream;
 using std::ifstream;
 using std::ofstream;
 
-#define unused  __attribute__((unused))
+#define vestigial  __attribute__((unused))

--- a/literate/layers/01/002main.cc
+++ b/literate/layers/01/002main.cc
@@ -17,7 +17,7 @@
 
 bool Interactive = false;
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/01/006infix.cc
+++ b/literate/layers/01/006infix.cc
@@ -236,6 +236,6 @@ bool is_parseable_as_float(string s) {
 
 const char* skip_float(const char* s) {
   char* end = NULL;
-  unused float dummy = strtof(s, &end);
+  vestigial float dummy = strtof(s, &end);
   return end;
 }

--- a/literate/layers/01/027stream.cc
+++ b/literate/layers/01/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/literate/layers/02_no_speculative/002main.cc
+++ b/literate/layers/02_no_speculative/002main.cc
@@ -17,7 +17,7 @@
 
 bool Interactive = false;
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/02_no_speculative/006infix.cc
+++ b/literate/layers/02_no_speculative/006infix.cc
@@ -236,6 +236,6 @@ bool is_parseable_as_float(string s) {
 
 const char* skip_float(const char* s) {
   char* end = NULL;
-  unused float dummy = strtof(s, &end);
+  vestigial float dummy = strtof(s, &end);
   return end;
 }

--- a/literate/layers/02_no_speculative/027stream.cc
+++ b/literate/layers/02_no_speculative/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/literate/layers/03_no_symbolic_eval/002main.cc
+++ b/literate/layers/03_no_symbolic_eval/002main.cc
@@ -17,7 +17,7 @@
 
 bool Interactive = false;
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/03_no_symbolic_eval/006infix.cc
+++ b/literate/layers/03_no_symbolic_eval/006infix.cc
@@ -236,6 +236,6 @@ bool is_parseable_as_float(string s) {
 
 const char* skip_float(const char* s) {
   char* end = NULL;
-  unused float dummy = strtof(s, &end);
+  vestigial float dummy = strtof(s, &end);
   return end;
 }

--- a/literate/layers/03_no_symbolic_eval/027stream.cc
+++ b/literate/layers/03_no_symbolic_eval/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/literate/layers/04_no_param_aliases/002main.cc
+++ b/literate/layers/04_no_param_aliases/002main.cc
@@ -17,7 +17,7 @@
 
 bool Interactive = false;
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/04_no_param_aliases/006infix.cc
+++ b/literate/layers/04_no_param_aliases/006infix.cc
@@ -236,6 +236,6 @@ bool is_parseable_as_float(string s) {
 
 const char* skip_float(const char* s) {
   char* end = NULL;
-  unused float dummy = strtof(s, &end);
+  vestigial float dummy = strtof(s, &end);
   return end;
 }

--- a/literate/layers/04_no_param_aliases/027stream.cc
+++ b/literate/layers/04_no_param_aliases/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/literate/layers/05_no_keyword_args/002main.cc
+++ b/literate/layers/05_no_keyword_args/002main.cc
@@ -17,7 +17,7 @@
 
 bool Interactive = false;
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/05_no_keyword_args/006infix.cc
+++ b/literate/layers/05_no_keyword_args/006infix.cc
@@ -236,6 +236,6 @@ bool is_parseable_as_float(string s) {
 
 const char* skip_float(const char* s) {
   char* end = NULL;
-  unused float dummy = strtof(s, &end);
+  vestigial float dummy = strtof(s, &end);
   return end;
 }

--- a/literate/layers/05_no_keyword_args/027stream.cc
+++ b/literate/layers/05_no_keyword_args/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/literate/layers/06_no_splice/002main.cc
+++ b/literate/layers/06_no_splice/002main.cc
@@ -17,7 +17,7 @@
 
 bool Interactive = false;
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/06_no_splice/006infix.cc
+++ b/literate/layers/06_no_splice/006infix.cc
@@ -236,6 +236,6 @@ bool is_parseable_as_float(string s) {
 
 const char* skip_float(const char* s) {
   char* end = NULL;
-  unused float dummy = strtof(s, &end);
+  vestigial float dummy = strtof(s, &end);
   return end;
 }

--- a/literate/layers/06_no_splice/027stream.cc
+++ b/literate/layers/06_no_splice/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/literate/layers/07_no_infix/002main.cc
+++ b/literate/layers/07_no_infix/002main.cc
@@ -17,7 +17,7 @@
 
 bool Interactive = false;
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/07_no_infix/027stream.cc
+++ b/literate/layers/07_no_infix/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/literate/layers/08_no_indent/002main.cc
+++ b/literate/layers/08_no_indent/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/08_no_indent/027stream.cc
+++ b/literate/layers/08_no_indent/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/literate/layers/09_no_$vars/002main.cc
+++ b/literate/layers/09_no_$vars/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/09_no_$vars/027stream.cc
+++ b/literate/layers/09_no_$vars/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/literate/layers/10_no_macro/002main.cc
+++ b/literate/layers/10_no_macro/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/10_no_macro/027stream.cc
+++ b/literate/layers/10_no_macro/027stream.cc
@@ -125,7 +125,7 @@ public:
       return *(unsigned char*)gptr();
    }
 
-   int overflow(unused int c) {
+   int overflow(vestigial int c) {
       return EOF;
    }
 

--- a/literate/layers/11_no_coerce/002main.cc
+++ b/literate/layers/11_no_coerce/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/12_no_lexical_scope/002main.cc
+++ b/literate/layers/12_no_lexical_scope/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/13_hardcoded_primitives/002main.cc
+++ b/literate/layers/13_hardcoded_primitives/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/14_no_compiled_fn/002main.cc
+++ b/literate/layers/14_no_compiled_fn/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/15_hardcoded_functions/002main.cc
+++ b/literate/layers/15_hardcoded_functions/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/16_no_user_defined_types/002main.cc
+++ b/literate/layers/16_no_user_defined_types/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/17_no_selective_quoting/002main.cc
+++ b/literate/layers/17_no_selective_quoting/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/18_no_scope/002main.cc
+++ b/literate/layers/18_no_scope/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/19_no_garbage_collection/002main.cc
+++ b/literate/layers/19_no_garbage_collection/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/20_no_comment_tokens/002main.cc
+++ b/literate/layers/20_no_comment_tokens/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/layers/22_no_interactive_mode_only_core_types/002main.cc
+++ b/literate/layers/22_no_interactive_mode_only_core_types/002main.cc
@@ -15,7 +15,7 @@
 // These weren't the reasons lisp was created; they're the reasons I attribute
 // to its power.
 
-int main(int argc, unused char* argv[]) {
+int main(int argc, vestigial char* argv[]) {
   if (argc > 1) {
     run_tests();
     return 0;

--- a/literate/tangle/001trace.cc
+++ b/literate/tangle/001trace.cc
@@ -75,7 +75,7 @@ trace_stream* Trace_stream = NULL;
 
 // RAISE << die exits after printing -- unless Hide_warnings is set.
 struct die {};
-ostream& operator<<(ostream& os, unused die) {
+ostream& operator<<(ostream& os, vestigial die) {
   if (Hide_warnings) return os;
   os << "dying";
   exit(1);

--- a/literate/tangle/boot.cc
+++ b/literate/tangle/boot.cc
@@ -1,4 +1,4 @@
-#define unused __attribute__((unused))
+#define vestigial __attribute__((unused))
 
 #include<cstdio>
 #include<cstring>


### PR DESCRIPTION
Hello Kartik, The  LLVM complier related bug that exists in 'mu' also happened be to exist this repo. I  applied a quick  search n replace. Please check the patch.